### PR TITLE
🚨 HOTFIX: Revert auto-fill integratie (productie kapot)

### DIFF
--- a/app/planning/_components/Wizard.tsx
+++ b/app/planning/_components/Wizard.tsx
@@ -1,4 +1,5 @@
 'use client';
+
 import React, { useEffect, useMemo, useState } from 'react';
 import { 
   computeDefaultStart, computeEnd, readRosters, writeRosters, type Roster,
@@ -7,7 +8,6 @@ import {
 import { getAllEmployees } from '@/lib/services/employees-storage';
 import { Employee, TeamType, DienstverbandType, getFullName } from '@/lib/types/employee';
 import { initializeRosterDesign } from '@/lib/planning/rosterDesign';
-import { initializePeriodStaffingForRoster } from '@/lib/services/period-day-staffing-storage';
 import { useRouter } from 'next/navigation';
 
 function genId() { return 'r_' + Math.random().toString(36).slice(2, 10) + Date.now().toString(36); }
@@ -71,9 +71,7 @@ export default function Wizard({ onClose }: WizardProps = {}) {
 
       // Fix: geef start_date expliciet mee aan initializeRosterDesign
       initializeRosterDesign(roster.id, selectedStart);
-      // ✨ Toegevoegde auto-fill integratie
-      initializePeriodStaffingForRoster(roster.id, selectedStart, []);
-
+      
       if (onClose) { onClose(); setTimeout(()=>router.push(`/planning/design?rosterId=${id}`), 100); }
       else { router.push(`/planning/design?rosterId=${id}`); }
     } catch (err) {


### PR DESCRIPTION
## 🚨 EMERGENCY HOTFIX

**Probleem:** PR #22 (auto-fill integratie) veroorzaakt runtime errors waardoor nieuwe roosters niet meer kunnen worden aangemaakt.

**Symptoom:** Infinite loading screen bij "Nieuw rooster aanmaken"

**Oplossing:** Revert `Wizard.tsx` naar werkende versie voor PR #22

---

### Wat is aangepast:
- ❌ Verwijderd: `import { initializePeriodStaffingForRoster }` regel 10
- ❌ Verwijderd: `initializePeriodStaffingForRoster(roster.id, selectedStart, []);` aanroep in `createRosterConfirmed()`
- ✅ Hersteld naar commit 92da68a (laatste werkende versie)

### Impact:
- ✅ Productie werkt weer direct na merge
- ✅ Nieuwe roosters kunnen weer worden aangemaakt
- ❌ Auto-fill functionaliteit is verwijderd (maar die werkte toch niet correct)

### Testen:
1. Merge deze PR direct (URGENT)
2. Wacht ~2 minuten op Vercel deployment
3. Test nieuw rooster aanmaken in productie
4. Verwacht: Wizard werkt normaal, geen loading hang

---

**PRIORITEIT: KRITISCH** - Productie is kapot, merge AUB direct! 🚨