### PR TITLE
🔧 DRAAD186 FIX #1: TypeScript type import resolution

### DIFF
--- a/app/services/assignments/page.tsx
+++ b/app/services/assignments/page.tsx
@@ -14,13 +14,17 @@ import { Input } from '@/components/ui/input';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { ArrowLeft, RefreshCw, Check, FileDown } from 'lucide-react';
 
+// FIX #1 DRAAD186: Direct type import (TypeScript compile-time resolution)
+// Reason: Lazy-import of types causes TypeScript build failure
+// Safe because: export const dynamic = 'force-dynamic' prevents static generation
+import type { EmployeeServiceRow } from '@/lib/types/employee-services';
+
 // LAZY IMPORT: Delay Supabase import until client-side rendering
 // This prevents "supabaseUrl is required" error during static generation
 let getEmployeeServicesOverview: any;
 let upsertEmployeeService: any;
 let getServiceIdByCode: any;
 let supabase: any;
-let EmployeeServiceRow: any;
 
 const loadSupabaseModules = async () => {
   if (!getEmployeeServicesOverview) {
@@ -29,9 +33,6 @@ const loadSupabaseModules = async () => {
     upsertEmployeeService = mod.upsertEmployeeService;
     getServiceIdByCode = mod.getServiceIdByCode;
     supabase = mod.supabase;
-    
-    const typesModule = await import('@/lib/types/employee-services');
-    EmployeeServiceRow = typesModule.EmployeeServiceRow;
   }
 };
 
@@ -39,7 +40,7 @@ export default function DienstenToewijzingPage() {
   const router = useRouter();
   const [loading, setLoading] = useState(true);
   const [exportingPDF, setExportingPDF] = useState(false);
-  const [data, setData] = useState<any[]>([]);
+  const [data, setData] = useState<EmployeeServiceRow[]>([]);
   const [serviceTypes, setServiceTypes] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);


### PR DESCRIPTION
## 🚨 Issue: TypeScript Build Failure (Deploy #28)

**Error:** `Property 'EmployeeServiceRow' does not exist on type...`  
**Location:** `app/services/assignments/page.tsx:34`  
**Root Cause:** Lazy-import of types causes TypeScript compile-time failure

## ✅ Solution: Direct Type Import

### Changes:
1. **Direct import** of `EmployeeServiceRow` type (compile-time resolution)
2. **Removed** lazy-import of types from `loadSupabaseModules`
3. **Kept** lazy-import of Supabase runtime modules
4. **Updated** state type: `useState<EmployeeServiceRow[]>([])`

### Why This Works:
- `export const dynamic = 'force-dynamic'` prevents static generation
- TypeScript compile-phase needs types immediately
- Runtime Supabase modules still lazy-load safely
- No Edge Runtime incompatibility issues

## 📊 Testing
- [x] Type checking passes
- [x] Code quality maintained
- [x] No runtime behavioral changes
- [x] Employee services flow unchanged

## 🎯 Expected Result
**Build should succeed** on Railway deploy without type resolution errors.

---

**Related Issues:** Deployment #27-28 failures  
**Deployed Services:** rooster-app-verloskunde, Solver2