### PR TITLE
🔧 OPDRACHT 195: Pydantic V2 Deprecation Warnings Fix

### DIFF
--- a/src/solver/greedy_api.py
+++ b/src/solver/greedy_api.py
@@ -13,7 +13,12 @@ Performance:
 - Coverage: 98%+
 - HTTP: 200 success (or 400/500 errors)
 
-Author: DRAAD 194 FASE 2
+FIXES (OPDRACHT 195):
+- Pydantic V2 deprecation: schema_extra → json_schema_extra
+- ConfigDict for model configuration
+- Clean logs without warnings
+
+Author: DRAAD 194 FASE 2 + OPDRACHT 195
 Date: 2025-12-16
 """
 
@@ -23,7 +28,7 @@ import traceback
 from datetime import datetime
 from typing import Dict, List, Optional, Any
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 import uuid
 
 from .greedy_engine import GreedyRosteringEngine, SolveResult
@@ -31,7 +36,7 @@ from .greedy_engine import GreedyRosteringEngine, SolveResult
 logger = logging.getLogger(__name__)
 
 # ============================================================================
-# REQUEST & RESPONSE MODELS (Pydantic)
+# REQUEST & RESPONSE MODELS (Pydantic V2)
 # ============================================================================
 
 class SolveRequest(BaseModel):
@@ -44,8 +49,8 @@ class SolveRequest(BaseModel):
         description="Maximum shifts per employee (default: 8)"
     )
     
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "roster_id": "550e8400-e29b-41d4-a716-446655440000",
                 "start_date": "2025-01-01",
@@ -53,6 +58,7 @@ class SolveRequest(BaseModel):
                 "max_shifts_per_employee": 8
             }
         }
+    )
 
 
 class BottleneckResponse(BaseModel):
@@ -81,8 +87,8 @@ class SolveResponse(BaseModel):
     solver_type: str = Field(default="GREEDY", description="Solver type (always 'GREEDY')")
     timestamp: str = Field(..., description="ISO8601 timestamp of solve")
     
-    class Config:
-        schema_extra = {
+    model_config = ConfigDict(
+        json_schema_extra={
             "example": {
                 "status": "success",
                 "assignments_created": 224,
@@ -97,6 +103,7 @@ class SolveResponse(BaseModel):
                 "timestamp": "2025-12-16T14:30:45.123456Z"
             }
         }
+    )
 
 
 # ============================================================================


### PR DESCRIPTION
## OPDRACHT 195 - GREEDY Service Log Cleanup

### Issue
Railway logs voor GREEDY service bevatten waarschuwingen:
```
'schema_extra' has been renamed to 'json_schema_extra'
Valid config keys have changed in V2
```

Oorzelevantie: Pydantic V1-syntaxis in models terwijl V2.8.0 actief is.

### Fix Toegepast
✅ **src/solver/greedy_api.py:**
- SolveRequest model: `class Config` → `model_config = ConfigDict(...)`
- SolveResponse model: `schema_extra` → `json_schema_extra`
- Import toegevoegd: `from pydantic import ConfigDict`

### Resultaat
- ✅ Pydantic V2 compliant
- ✅ Schone Railway logs (geen [err] warnings meer)
- ✅ Geen functionaliteit verandering
- ✅ Production-ready logging

### Testing
- [ ] Railway rebuild (cache-bust nodig)
- [ ] Verify clean logs
- [ ] Verify `/api/greedy/health` still responds
- [ ] Verify endpoints beschikbaar

### Links
- DRAAD 194: https://github.com/gslooters/rooster-app-verloskunde/commits/main (FASE 2 implementation)
- Railway Service: https://greedy-production.up.railway.app
- PR: Fix/OPDRACHT-195-pydantic-v2-deprecations

### Checklist
- [x] Code fixes applied
- [x] Pydantic V2 syntax migration complete
- [x] No breaking changes
- [ ] Railway rebuild + test (pending)
- [ ] Production deployment (pending)

---
**Branch:** fix/OPDRACHT-195-pydantic-v2-deprecations  
**Created:** 2025-12-16 16:07 UTC  
**Related:** DRAAD 194 FASE 2, OPDRACHT 195 Analysis